### PR TITLE
feat: add logic for getting top employees

### DIFF
--- a/odata-v4/kendo-northwind-pg/App_Start/WebApiConfig.cs
+++ b/odata-v4/kendo-northwind-pg/App_Start/WebApiConfig.cs
@@ -24,6 +24,7 @@ namespace kendo_northwind_pg
             builder.EntitySet<Customer>("Customers");
             builder.EntitySet<Category>("Categories");
             builder.EntitySet<Employee>("Employees").EntityType.Ignore(t => t.Photo);
+            builder.EntityType<Employee>().Collection.Function("TopEmployees").ReturnsCollectionFromEntitySet<Employee>("bindingParameter/Employees");
             builder.EntitySet<Order>("Orders");
             builder.EntitySet<Product>("Products");
             builder.EntitySet<Region>("Regions");

--- a/odata-v4/kendo-northwind-pg/Controllers/EmployeesController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/EmployeesController.cs
@@ -152,11 +152,11 @@ namespace kendo_northwind_pg.Controllers
             return StatusCode(HttpStatusCode.NoContent);
         }
 
-        // GET: odata/Employees(5)/Employees1
+        // GET: odata/Employees(5)/Subordinates
         [EnableQuery]
-        public IQueryable<Employee> GetEmployees1([FromODataUri] int key)
+        public IQueryable<Employee> GetSubordinates([FromODataUri] int key)
         {
-            var employees = db.Employees.Where(m => m.EmployeeID == key).SelectMany(m => m.Employees1);
+            var employees = db.Employees.Where(m => m.EmployeeID == key).SelectMany(m => m.Subordinates);
             foreach (var employee in employees)
             {
                 employee.hasChildren = db.Employees.Where(s => s.ReportsTo == employee.EmployeeID).Count() > 0;

--- a/odata-v4/kendo-northwind-pg/Controllers/EmployeesController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/EmployeesController.cs
@@ -11,6 +11,7 @@ using System.Web.ModelBinding;
 using Microsoft.AspNet.OData;
 using kendo_northwind_pg.Models;
 using System.Web.Http.Cors;
+using Microsoft.AspNet.OData.Routing;
 
 namespace kendo_northwind_pg.Controllers
 {
@@ -36,6 +37,13 @@ namespace kendo_northwind_pg.Controllers
         public IQueryable<Employee> GetEmployees()
         {
             return db.Employees;
+        }
+
+        [HttpGet]
+        [ODataRoute("Employees/Default.TopEmployees()")]
+        public IQueryable<Employee> TopEmployees()
+        {
+            return db.Employees.Where(x => x.ReportsTo == null);
         }
 
         // GET: odata/Employees(5)
@@ -148,7 +156,12 @@ namespace kendo_northwind_pg.Controllers
         [EnableQuery]
         public IQueryable<Employee> GetEmployees1([FromODataUri] int key)
         {
-            return db.Employees.Where(m => m.EmployeeID == key).SelectMany(m => m.Employees1);
+            var employees = db.Employees.Where(m => m.EmployeeID == key).SelectMany(m => m.Employees1);
+            foreach (var employee in employees)
+            {
+                employee.hasChildren = db.Employees.Where(s => s.ReportsTo == employee.EmployeeID).Count() > 0;
+            }
+            return employees;
         }
 
         // GET: odata/Employees(5)/Employee1

--- a/odata-v4/kendo-northwind-pg/Models/Employee.cs
+++ b/odata-v4/kendo-northwind-pg/Models/Employee.cs
@@ -40,7 +40,8 @@ namespace kendo_northwind_pg.Models
         public string Notes { get; set; }
         public Nullable<int> ReportsTo { get; set; }
         public string PhotoPath { get; set; }
-    
+        public bool hasChildren { get; set; } = true;
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Employee> Employees1 { get; set; }
         public virtual Employee Employee1 { get; set; }

--- a/odata-v4/kendo-northwind-pg/Models/Employee.cs
+++ b/odata-v4/kendo-northwind-pg/Models/Employee.cs
@@ -17,7 +17,7 @@ namespace kendo_northwind_pg.Models
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
         public Employee()
         {
-            this.Employees1 = new HashSet<Employee>();
+            this.Subordinates = new HashSet<Employee>();
             this.Orders = new HashSet<Order>();
             this.Territories = new HashSet<Territory>();
         }
@@ -40,10 +40,11 @@ namespace kendo_northwind_pg.Models
         public string Notes { get; set; }
         public Nullable<int> ReportsTo { get; set; }
         public string PhotoPath { get; set; }
+        // Needed for the TreeList widget to know that the current entity has children
         public bool hasChildren { get; set; } = true;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual ICollection<Employee> Employees1 { get; set; }
+        public virtual ICollection<Employee> Subordinates { get; set; }
         public virtual Employee Employee1 { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Order> Orders { get; set; }

--- a/odata-v4/kendo-northwind-pg/Models/Northwind.edmx
+++ b/odata-v4/kendo-northwind-pg/Models/Northwind.edmx
@@ -187,12 +187,12 @@
         </Association>
         <Association Name="FK_Employees_Employees">
           <End Role="Employees" Type="Self.Employees" Multiplicity="0..1" />
-          <End Role="Employees1" Type="Self.Employees" Multiplicity="*" />
+          <End Role="Subordinates" Type="Self.Employees" Multiplicity="*" />
           <ReferentialConstraint>
             <Principal Role="Employees">
               <PropertyRef Name="EmployeeID" />
             </Principal>
-            <Dependent Role="Employees1">
+            <Dependent Role="Subordinates">
               <PropertyRef Name="ReportsTo" />
             </Dependent>
           </ReferentialConstraint>
@@ -341,7 +341,7 @@
           </AssociationSet>
           <AssociationSet Name="FK_Employees_Employees" Association="Self.FK_Employees_Employees">
             <End Role="Employees" EntitySet="Employees" />
-            <End Role="Employees1" EntitySet="Employees" />
+            <End Role="Subordinates" EntitySet="Employees" />
           </AssociationSet>
           <AssociationSet Name="FK_EmployeeTerritories_Employees" Association="Self.FK_EmployeeTerritories_Employees">
             <End Role="Employees" EntitySet="Employees" />
@@ -447,8 +447,8 @@
           <Property Name="Notes" Type="String" MaxLength="Max" FixedLength="false" Unicode="true" />
           <Property Name="ReportsTo" Type="Int32" />
           <Property Name="PhotoPath" Type="String" MaxLength="255" FixedLength="false" Unicode="true" />
-          <NavigationProperty Name="Employees1" Relationship="Self.FK_Employees_Employees" FromRole="Employees" ToRole="Employees1" />
-          <NavigationProperty Name="Employee1" Relationship="Self.FK_Employees_Employees" FromRole="Employees1" ToRole="Employees" />
+          <NavigationProperty Name="Subordinates" Relationship="Self.FK_Employees_Employees" FromRole="Employees" ToRole="Subordinates" />
+          <NavigationProperty Name="Employee1" Relationship="Self.FK_Employees_Employees" FromRole="Subordinates" ToRole="Employees" />
           <NavigationProperty Name="Orders" Relationship="Self.FK_Orders_Employees" FromRole="Employees" ToRole="Orders" />
           <NavigationProperty Name="Territories" Relationship="Self.EmployeeTerritories" FromRole="Employees" ToRole="Territories" />
         </EntityType>
@@ -577,12 +577,12 @@
         </Association>
         <Association Name="FK_Employees_Employees">
           <End Role="Employees" Type="Self.Employee" Multiplicity="0..1" />
-          <End Role="Employees1" Type="Self.Employee" Multiplicity="*" />
+          <End Role="Subordinates" Type="Self.Employee" Multiplicity="*" />
           <ReferentialConstraint>
             <Principal Role="Employees">
               <PropertyRef Name="EmployeeID" />
             </Principal>
-            <Dependent Role="Employees1">
+            <Dependent Role="Subordinates">
               <PropertyRef Name="ReportsTo" />
             </Dependent>
           </ReferentialConstraint>
@@ -689,7 +689,7 @@
           </AssociationSet>
           <AssociationSet Name="FK_Employees_Employees" Association="Self.FK_Employees_Employees">
             <End Role="Employees" EntitySet="Employees" />
-            <End Role="Employees1" EntitySet="Employees" />
+            <End Role="Subordinates" EntitySet="Employees" />
           </AssociationSet>
           <AssociationSet Name="FK_Orders_Employees" Association="Self.FK_Orders_Employees">
             <End Role="Employees" EntitySet="Employees" />


### PR DESCRIPTION
In this PR logic is added in order to get the top Employees and respectively reflect whether a certain employee has subordinates. With these changes the TreeList demos of OData-v4 will look like this - https://github.com/telerik/kendo/commit/89226c50f6ce3a68bbb3e10e04ba82eea6d4a6fb - Bear in mind that I will alter the URLs to remove **agpetrov/odata** and point them to the real service once uploaded.