### PR TITLE
fix: enable CORS globally

### DIFF
--- a/odata-v4/kendo-northwind-pg/Controllers/CategoriesController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/CategoriesController.cs
@@ -25,7 +25,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Product>("Products"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class CategoriesController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/CustomersController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/CustomersController.cs
@@ -26,7 +26,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<CustomerDemographic>("CustomerDemographics"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class CustomersController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/EmployeesController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/EmployeesController.cs
@@ -27,7 +27,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Territory>("Territories"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class EmployeesController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/Order_DetailController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/Order_DetailController.cs
@@ -26,7 +26,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Product>("Products"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class Order_DetailController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/OrdersController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/OrdersController.cs
@@ -24,7 +24,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Shipper>("Shippers"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class OrdersController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/ProductsController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/ProductsController.cs
@@ -27,7 +27,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Supplier>("Suppliers"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class ProductsController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/RegionsController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/RegionsController.cs
@@ -25,7 +25,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Territory>("Territories"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class RegionsController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/ShippersController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/ShippersController.cs
@@ -25,7 +25,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Order>("Orders"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class ShippersController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/SuppliersController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/SuppliersController.cs
@@ -25,7 +25,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Product>("Products"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class SuppliersController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Controllers/TerritoriesController.cs
+++ b/odata-v4/kendo-northwind-pg/Controllers/TerritoriesController.cs
@@ -26,7 +26,6 @@ namespace kendo_northwind_pg.Controllers
     builder.EntitySet<Employee>("Employees"); 
     config.MapODataServiceRoute("odata", "odata", builder.GetEdmModel());
     */
-    [EnableCors(origins: "*", headers: "*", methods: "*")]
     public class TerritoriesController : ODataController
     {
         private NorthwindEntities db = new NorthwindEntities();

--- a/odata-v4/kendo-northwind-pg/Web.config
+++ b/odata-v4/kendo-northwind-pg/Web.config
@@ -17,7 +17,14 @@
     </httpModules>
   </system.web>
   <system.webServer>
-    
+    <httpProtocol>
+      <customHeaders>
+        <clear />
+          <add name="Access-Control-Allow-Origin" value="*" />
+          <add name="Access-Control-Allow-Headers" value="Content-Type" />
+          <add name="Access-Control-Allow-Methods" value="GET,POST,PUT,DELETE,OPTIONS" />
+        </customHeaders>
+    </httpProtocol>
     <validation validateIntegratedModeConfiguration="false" />
     <modules>
       <remove name="ApplicationInsightsWebTracking" />
@@ -25,10 +32,10 @@
     </modules>
   <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
       <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers></system.webServer>
+    </handlers>
+  </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
I have tried almost every suggestion on how to enable correctly CORS for the service and that is the final one which I ended with. It seems that **EnableCors** attributes for the controllers only allows **GET** request to be performed for an unknown reason. When enabling CORS globally in the **web.config** which is pretty much the same, all works fine. One addition that I have made is to keep the **OPTIONSVerbHandler**. When using CORS with pre-flight(Chrome executes such a request) this handler is needed. In essence what happens is that the browser send an **OPTIONS** request to verify that a cross origin request can be made and if the OPTIONS handler returns the correct result(sample and additional info can be found [here](https://docs.microsoft.com/en-us/aspnet/core/security/cors?view=aspnetcore-2.1)) the browser executes the actual request.

I have tested the solution locally and it seems to work.