### PR TITLE
chore: update base graphql path

### DIFF
--- a/graphql/graphql-aspnet-core/graphql-aspnet-core/Controllers/GraphQLController.cs
+++ b/graphql/graphql-aspnet-core/graphql-aspnet-core/Controllers/GraphQLController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace graphql_aspnet_core.Controllers
 {
-    [Route("[controller]")]
+    [Route("")]
     public class GraphQLController : Controller
     {
         private readonly IDocumentExecuter _documentExecuter;


### PR DESCRIPTION
The base controller will be available at "/" instead of "/graphql".

The rest remain as is.